### PR TITLE
fix problem with first content-type child in edit mode

### DIFF
--- a/extensions/content-manager/admin/src/components/SettingsViewWrapper/index.js
+++ b/extensions/content-manager/admin/src/components/SettingsViewWrapper/index.js
@@ -171,7 +171,7 @@ const SettingsViewWrapper = ({
     const relationNameOptions = getRelationNameOptions();
     return relationNameOptions.length === 1 && relationNameOptions.includes("")
   }
-
+  //to fix in next buffet js release (right now we are unable to disable switch)
   const filterInputsByRelation = () => {
     const filteredInputs = inputs.filter(input => {
       return input.name !== 'settings.relationKey' && input.name !== 'settings.relationName'

--- a/extensions/content-type-builder/services/relation-builder/relation-template.js
+++ b/extensions/content-type-builder/services/relation-builder/relation-template.js
@@ -27,6 +27,10 @@ const validateRelation = async(ctx) => {
     data  = await strapi.services.placeholder.find(ctx.query);
   }
 
+  if(parentId === 'create') {
+    return ({isCorrect: true})
+  }
+
   const relationStructure = strapi.services.relation.prepareNewStructure(childId, parentId, data, relationName);
   return ({isCorrect: strapi.services.relation.isRelationStructureCorrect(data, relationStructure, relationName)})
 }


### PR DESCRIPTION
## What did you implement?
Fixing bug related to edit mode for first content-type child
## How it might be Tested?
1. Create content-type with correct relation (one-way content-type->the-same-content-type)
2. Turn on the realtion view 
3. Try to edit content-type child 
4. Check if relation endpoint works fine

## For reviewers

**Files changed & to be reviewed**
all PR files
